### PR TITLE
Deprecated functions & Throw error if photos directory doesn't exist or isn't writeable

### DIFF
--- a/osc/execute.php
+++ b/osc/execute.php
@@ -113,6 +113,33 @@ case "camera.takePicture":
   echo(command_take_picture($parameters["sessionId"]));
   break;
 
+case "camera.listFiles":
+  if (!isset($parameters["fileType"])) {
+    echo format_error("camera.listFiles", "missingParameter",
+      "Required parameter fileType not specified");
+    exit;
+  }
+  if (!isset($parameters["entryCount"])) {
+    echo format_error("camera.listFiles", "missingParameter",
+      "Required parameter entryCount not specified");
+    exit;
+  } 
+  if (!isset($parameters["startPosition"])) {
+    $parameters["startPosition"] = 0;
+  }
+  if (!isset($parameters["maxThumbSize"])) {
+    echo format_error("camera.listFiles", "missingParameter",
+      "Required parameter maxThumbSize not specified");
+    exit;
+  }
+  ensure_no_invalid_parameters(array(
+      "entryCount", "maxThumbSize", "fileType", "startPosition"
+    ), $parameters, $name);
+  keepalive_sessions();
+  echo(command_list_files($parameters["entryCount"], $parameters["maxThumbSize"],
+    $parameters["fileType"], $parameters["startPosition"]));
+  break;
+
 case "camera.listImages":
   if (!isset($parameters["entryCount"])) {
     echo format_error("camera.listImages", "missingParameter",

--- a/osc/implementation/capture-functions.php
+++ b/osc/implementation/capture-functions.php
@@ -29,8 +29,28 @@ function capture_image() {
   // copy images to new location
   $newImage = "photos/" . $newName . "-full.jpg";
   $newThumbnail = "photos/" . $newName . "-thumbnail.jpg";
-  copy($image, $newImage);
-  copy($thumbnail, $newThumbnail);
+  // check if photos directory exists and create if needed
+  if (!file_exists("photos") && !is_dir("photos")) {
+    if (!mkdir("photos")) {
+      $errors = error_get_last();
+      echo "Error: ".$errors['type']."\n";
+      echo $errors['message']."\n";
+      return false;
+    }    
+  }
+  // check if php copy succeeds 
+  if (!copy($image, $newImage)) {
+    $errors = error_get_last();
+    echo "Error: ".$errors['type']."\n";
+    echo $errors['message']."\n";
+    return false;
+  }
+  if (!copy($thumbnail, $newThumbnail)) {
+    $errors = error_get_last();
+    echo "Error: ".$errors['type']."\n";
+    echo $errors['message']."\n";
+    return false;
+  }
   // get URI
   $uri = str_replace("photos/", "", $newImage);
   $uri = str_replace("-full.jpg", "", $uri);

--- a/osc/includes/image-commands.php
+++ b/osc/includes/image-commands.php
@@ -66,6 +66,27 @@ function command_list_images($entryCount, $maxSize, $continuationToken = "",
   return format_results("camera.listImages", $images);
 }
 
+function command_list_files($entryCount, $maxThumbSize, $continuationToken = "",
+    $fileType, $startPosition) {
+  // limit to 100 entries if not specified
+  if ($entryCount <= 0 || $entryCount >= 100) {
+    $entryCount = 100;
+  }
+  // get list of files
+  $images = get_file_list($start, $entryCount);
+
+  if ($images === false) {
+    return format_error("camera.listFiles", "serverError",
+      "unable to retrieve images");
+  }
+  // retrieve thumbnails if requested
+  foreach ($images['entries'] as &$image) {
+    $image['thumbnail'] = base64_encode(get_image($image['uri'], $maxSize));
+  }
+  // return results
+  return format_results("camera.listFiles", $images);
+}
+
 function command_delete($uri) {
   if (delete_image($uri) === false) {
     return format_error("camera.delete", "invalidParameterValue",


### PR DESCRIPTION
In the latest version a check is missing if the photos directory exists and if it's possible to copy files to it.

This commit checks if php is able to create the directory and throws error messages if php doesn't have sufficient permissions.

Also `listImages` is a deprecated since api v1 and should be replaced with `listFiles`, see commit two.
